### PR TITLE
Restart NetworkManager after dispatcher scripts creation

### DIFF
--- a/provisioning/networking/configure-default-route.sh
+++ b/provisioning/networking/configure-default-route.sh
@@ -53,3 +53,6 @@ fi\\n" \
   chmod a+x "$up_event_script_path"
   chmod u+rw "$up_event_script_path"
 fi
+
+echo "Restarting NetworkManager service to let it pick up configuration changes"
+systemctl restart NetworkManager.service


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR fixes #33
It restarts the NetworkManager service when we are done configuring scripts in `/etc/NetworkManager/dispatcher.d/`.

### Alternate Designs

N/A

### Benefits

With this change such scripts are executed even when configuring network interfaces via DHCP on the first "interface up" event received by NetworkManager.

Event flow before this change (when configuring network interfaces with DHCP):
1. Configure NetworkManager
1. Configure dispatcher scripts

Dispatcher scripts that are listening for "interface up" or "link up" events are not executed because all the interfaces managed by NetworkManager are already up.

Event flow after this change:
1. Configure NetworkManager
1. Configure dispatcher scripts
1. Restart NetworkManager service

Dispatcher scripts are evaluated because when the NetworkManager service starts, it brings up all the network interfaces it manages.

### Possible Drawbacks

N/A

### Applicable Issues

#33 
