### PR TITLE
Changed prelude-manager-oss provisioning to bento/fedora-26

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ NETWORK_TYPE_STATIC_IP = "static_ip"
 UPSTREAM_DNS_SERVER = "8.8.8.8"
 SUBNET_MASK = "255.0.0.0"
 UBUNTU_BOX_ID = "bento/ubuntu-16.04"
+FEDORA_BOX_ID = "bento/fedora-26"
 
 # VM names
 D_STREAMON_MASTER_VM_NAME = "d-streamon-master"
@@ -137,7 +138,7 @@ scissor = {
   },
   PRELUDE_MANAGER_VM_NAME => {
     :autostart => true,
-    :box => CENTOS_BOX_ID,
+    :box => FEDORA_BOX_ID,
     :cpus => 1,
     :mac_address => "0800271F9D09",
     :mem => 1024,

--- a/provisioning/prelude-manager-oss/deployment.sh
+++ b/provisioning/prelude-manager-oss/deployment.sh
@@ -24,7 +24,7 @@ GRANT ALL PRIVILEGES ON ${MARIADB_PRELUDE_DBNAME}.* TO '${MARIADB_PRELUDE_USER}'
 UPDATE mysql.user SET Password=PASSWORD('${MARIADB_ROOT_PASS}') WHERE User='root';
 FLUSH PRIVILEGES;
 EOF
-mysql -u "${MARIADB_PRELUDE_USER}" "${MARIADB_PRELUDE_DBNAME}" -p"${MARIADB_PRELUDE_PASS}" < /usr/share/libpreludedb/classic/mysql.sql
+mysql -u "${MARIADB_PRELUDE_USER}" --password="${MARIADB_PRELUDE_PASS}" --database="${MARIADB_PRELUDE_DBNAME}" < /usr/share/libpreludedb/classic/mysql.sql
 
 systemctl restart prelude-manager
 

--- a/provisioning/prelude-manager-oss/install-packages.sh
+++ b/provisioning/prelude-manager-oss/install-packages.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -exe
 
-yum install -y \
-  libprelude \
-  mariadb-server \
-  prelude-manager \
-  prelude-manager-db-plugin \
-  prelude-tools \
-  preludedb-mysql \
-  pwgen
+dnf install -y
+libpreludedb
+mariadb-server
+prelude-manager
+prelude-manager-db-plugin
+prelude-tools
+preludedb-mysql
+preludedb-tools
+pwgen

--- a/provisioning/prelude-manager-oss/install-packages.sh
+++ b/provisioning/prelude-manager-oss/install-packages.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -exe
 
-dnf install -y
-libpreludedb
-mariadb-server
-prelude-manager
-prelude-manager-db-plugin
-prelude-tools
-preludedb-mysql
-preludedb-tools
-pwgen
+dnf install -y \
+  libpreludedb \
+  mariadb-server \
+  prelude-manager \
+  prelude-manager-db-plugin \
+  prelude-tools \
+  preludedb-mysql \
+  preludedb-tools \
+  pwgen

--- a/provisioning/prelude-manager-oss/post-install.sh
+++ b/provisioning/prelude-manager-oss/post-install.sh
@@ -16,10 +16,8 @@ DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
 FLUSH PRIVILEGES;
 EOF
 
-#adduser --system prelude-manager
-
 # Create prelude-manager profile
-#prelude-admin add "prelude-manager" --uid $(id -u prelude-manager) --gid $(id -g prelude-manager)
+prelude-admin add "prelude-manager" --uid 0 --gid 0
 
 cat << "EOF" > /etc/prelude-manager/prelude-manager.conf
 # Prelude Manager configuration file.
@@ -449,3 +447,8 @@ WantedBy=multi-user.target
 EOF
 
 systemctl enable prelude-registrator
+
+iptables -I INPUT -p tcp -s 0.0.0.0/0 --dport 4690 -j ACCEPT
+iptables -I INPUT -p tcp -s 0.0.0.0/0 --dport 5553 -j ACCEPT
+
+mkdir -p /var/run/prelude-manager

--- a/provisioning/prelude-manager-oss/pre-install.sh
+++ b/provisioning/prelude-manager-oss/pre-install.sh
@@ -3,7 +3,5 @@
 set -xeuo pipefail
 IFS=$'\\n\t'
 
-yum install -y epel-release
-
-yum clean all
-rm -rf /var/cache/yum
+dnf clean all
+rm -rf /var/cache/dnf


### PR DESCRIPTION
### Description of the Change

Changed prelude-manager-oss provisioning to bento/fedora-26 . We install packages with _dnf_ package manager. 

### Alternate Designs

N/A

### Benefits

With these changes, a sensor is able to register to _prelude-manager_ .

### Possible Drawbacks

N/A

### Applicable Issues
#35 
