### PR TITLE
Disable Vagrant interface default route in fedora

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -253,11 +253,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       if(GATEWAY_IP_ADDRESS != ip_address)
         # Ensure we are going through the gateway
-        host.vm.provision "shell" do |s|
-          s.path = "provisioning/networking/configure-default-route.sh"
-          s.args = [
-            "--ip-v4-gateway-ip-address", GATEWAY_IP_ADDRESS
-            ]
+
+        if(UBUNTU_BOX_ID == info[:box])
+          host.vm.provision "shell" do |s|
+            s.path = "provisioning/networking/configure-default-route.sh"
+            s.args = [
+              "--ip-v4-gateway-ip-address", GATEWAY_IP_ADDRESS
+              ]
+          end
+        elsif(FEDORA_BOX_ID == info[:box])
+          # In Fedora ip route commands have no effect for this configuration
+          # so we have to explicitely disable the default route of the network
+          # interface managed by Vagrant
+          host.vm.provision "shell", path: "provisioning/networking/configure-default-route-fedora.sh"
         end
       end
 

--- a/provisioning/networking/configure-default-route-fedora.sh
+++ b/provisioning/networking/configure-default-route-fedora.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+vagrant_interface="$(find /sys/class/net \( -not -name lo -and -not -name 'docker*' -and -not -type d \) -printf "%f\\n" | sort | sed -n '1p')"
+vagrant_network_configuration_file_path="/etc/sysconfig/network-scripts/ifcfg-$vagrant_interface"
+echo "Disabling default route for Vagrant managed interface ($vagrant_interface)"
+sed -i '/DEFROUTE/d' "$vagrant_network_configuration_file_path" && echo "DEFROUTE=\"no\"" >> "$vagrant_network_configuration_file_path"
+echo "Restarting NetworkManager service to let it pick up configuration changes"
+systemctl restart NetworkManager.service
+sleep 5
+echo "Current IP routes:
+$(ip route)"


### PR DESCRIPTION
<!--

Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

-->
### Description of the Change

This PR disables the default route provided by the network interface (that is managed by Vagrant) on Fedora.

### Alternate Designs

I tried with the provisioning we already apply to Ubuntu and CentOS (script that reacts to "interface up" events, executing the relevant `ip route add default ...` commands). This approach does not work with Fedora 26 and interfaces configured with NetworkManager.

### Benefits

A default route is configured in Fedora-based VMs.

### Possible Drawbacks

Maintain two different (and distribution dependent) network configuration scripts.
I was not able to make `ip route add default ...` command work in Fedora :cry: 

### Applicable Issues

#35 
