### PR TITLE
Saved prelude-manager-oss iptables rules after reload

### DIFF
--- a/provisioning/prelude-manager-oss/install-packages.sh
+++ b/provisioning/prelude-manager-oss/install-packages.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -exe
 
 dnf install -y \
+  iptables-services \
   libpreludedb \
   mariadb-server \
   prelude-manager \

--- a/provisioning/prelude-manager-oss/post-install.sh
+++ b/provisioning/prelude-manager-oss/post-install.sh
@@ -448,7 +448,18 @@ EOF
 
 systemctl enable prelude-registrator
 
+systemctl mask firewalld.service
+systemctl enable iptables.service
+systemctl enable ip6tables.service
+
 iptables -I INPUT -p tcp -s 0.0.0.0/0 --dport 4690 -j ACCEPT
 iptables -I INPUT -p tcp -s 0.0.0.0/0 --dport 5553 -j ACCEPT
+
+#saving iptables rules
+iptables-save > /etc/sysconfig/iptables
+
+systemctl stop firewalld.service
+systemctl start iptables.service
+systemctl start ip6tables.service
 
 mkdir -p /var/run/prelude-manager


### PR DESCRIPTION
Used iptables-services to save iptables rules

We use only iptables and not firewalld

### Description of the Change

Saved prelude-manager-oss iptables rules after reload.

### Alternate Designs

N/A

### Benefits

After this, _prelude-manager_'s iptables rules persist even if `vagrant reload prelude-manager-oss` is executed. 
### Possible Drawbacks

N/A

### Applicable Issues

#38 