### PR TITLE
Make prelude-manager service resilient to reboots by configuring it as a service

### DIFF
--- a/provisioning/prelude-manager-oss/post-install.sh
+++ b/provisioning/prelude-manager-oss/post-install.sh
@@ -433,6 +433,19 @@ hook = reporting
 # 90 seconds.
 EOF
 
+cat << EOF > /etc/systemd/system/prelude-manager.service
+[Unit]
+Description=Prelude Manager
+Documentation=man:prelude-manager(1)
+After=mariadb.service
+
+[Service]
+ExecStart=/usr/sbin/prelude-manager
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
 systemctl enable prelude-manager
 
 cat << EOF > /etc/systemd/system/prelude-registrator.service
@@ -462,4 +475,4 @@ systemctl stop firewalld.service
 systemctl start iptables.service
 systemctl start ip6tables.service
 
-mkdir -p /var/run/prelude-manager
+echo "d /var/run/prelude-manager 755 root root -" > /usr/lib/tmpfiles.d/prelude-manager.conf


### PR DESCRIPTION
### Description of the Change

1. Made prelude-manager service resilient to reboots.
1. Now prelude-manager starts after mariadb service

### Alternate Designs

N/A

### Benefits

Now prelude-manager can connect to _mariadb_ even if `vagrant reload prelude-manager-oss` is executed.

### Possible Drawbacks

N/A

### Applicable Issues

#41 