### PR TITLE
Add a prefix to the locally managed domain

### DIFF
--- a/docker/scissor-dnsmasq/etc/dnsmasq.conf
+++ b/docker/scissor-dnsmasq/etc/dnsmasq.conf
@@ -30,7 +30,7 @@ dhcp-option=option:router,10.10.0.1
 dhcp-range=10.0.0.2,10.255.255.254,255.0.0.0,2h
 
 # Set the local domain
-domain=scissor-project.com,10.0.0.0/8,local
+domain=dev.scissor-project.com,10.0.0.0/8,local
 
 # Don't pass short names to the upstream DNS servers
 domain-needed


### PR DESCRIPTION
<!--

Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

-->
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This change adds a prefix (**dev.**) to the local DNS domain (`scissor-project.com`). So the _new_ local domain becomes: `dev.scissor-project.com`

This is needed to fix issues like #43, when we want to query the upstream `scissor-project.com` DNS server but we cannot because our DNS server thinks it should answer.

Note that after https://github.com/scissor-project/open-scissor/commit/6761cfdb7c83beb75dd7f0a68aca9f544696aad9 there is only one place where the domain is defined: the DNSMasq configuration file.

### Alternate Designs

N/A

### Benefits

DNS queries to `scissor-project.com` are correctly forwarded to the upstream DNS server.

### Possible Drawbacks

N/A

### Applicable Issues

#43 
