### PR TITLE
Modified configuration syntax in kafka-idmef-converter

### DIFF
--- a/provisioning/kafka-idmef-converter/post-install.sh
+++ b/provisioning/kafka-idmef-converter/post-install.sh
@@ -7,16 +7,14 @@ pip install --upgrade pip
 pip install kafka
 
 cat <<EOF > /etc/converter.conf
-[Config]
+kafka_server: __KAFKA_SERVER__
+kafka_port: __KAFKA_PORT__
 
-kafka_server = __KAFKA_SERVER__
-kafka_port = __KAFKA_PORT__
+consumer_topics: [__CONSUMER_TOPICS__]
 
-# topics the consumer will subscribe
-consumer_topics = __CONSUMER_TOPICS__
+producer_topic: __PRODUCER_TOPIC__
 
-# topic where the IDMEF will be sent
-producer_topic = __PRODUCER_TOPIC__
+block_filters : []
 EOF
 
 systemctl enable converter


### PR DESCRIPTION
### Description of the Change

Modified configuration syntax in kafka-idmef-converter.
Replaced marker "=" with ":" .

### Alternate Designs

N/A

### Benefits

Now kafka-idmef-converter is able to read configuration file properly.

### Possible Drawbacks

N/A

### Applicable Issues

#48 #49 