### PR TITLE
New iptables rules to open 2181 and  9092 in kafka VM

### DIFF
--- a/provisioning/kafka/post-install.sh
+++ b/provisioning/kafka/post-install.sh
@@ -43,3 +43,9 @@ mkdir zookeeper-master
 cd zookeeper-master
 git clone -b master https://anc-git.salzburgresearch.at/ppaiva/zookeeper-master.git .
 log "Cloned zookeeper-master"
+
+iptables -I INPUT -p tcp -s 0.0.0.0/0 --dport 9092 -j ACCEPT
+iptables -I INPUT -p tcp -s 0.0.0.0/0 --dport 2181 -j ACCEPT
+
+mkdir -p /etc/iptables
+iptables-save > /etc/iptables/rules.v4


### PR DESCRIPTION
Now kafka is able to accept connections on 9092 and 2181

### Description of the Change

New iptables rules in kafka VM (ports 9092 and 2181).

### Alternate Designs

N/A

### Benefits

Now kafka-idmef-converter and the other clients are able to connect to kafka.

### Possible Drawbacks

N/A

### Applicable Issues

#49 #48 #53 