### PR TITLE
Fixed wrong startup conf

### DIFF
--- a/docker/raw-data-analyzer/start-raw-data-analyzer.sh
+++ b/docker/raw-data-analyzer/start-raw-data-analyzer.sh
@@ -7,7 +7,7 @@ while ! ncat -vvz kafka 9092; do echo "Wating 10 secs..."; sleep 10; done
 # workaround for tail -F saying: "has been replaced with a remote file. giving up on this name"
 truncate -s0 "$SCISSOR_LOG_DIR"/raw-data-analyzer-output.log;
 
-sh -c "converter /etc/envMonAnalyzer.conf" > "$SCISSOR_LOG_DIR"/raw-data-analyzer-output.log 2>&1 &
+sh -c "converter /etc/converter.conf" > "$SCISSOR_LOG_DIR"/raw-data-analyzer-output.log 2>&1 &
 
 tail -F \
   "$SCISSOR_LOG_DIR"/raw-data-analyzer-output.log


### PR DESCRIPTION
<!--

Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

-->
### Description of the Change

Fixed wrong startup conf in raw-data-analyzer. This was producing anomalous prints derived from exoscale kafka events received. Now we should have open-scissor conf.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

raw-data-analyzer can use open-scissor conf with kafka host.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
#78 
